### PR TITLE
Use quorum queues

### DIFF
--- a/lib/sneakers_handlers/exponential_backoff_handler.rb
+++ b/lib/sneakers_handlers/exponential_backoff_handler.rb
@@ -178,7 +178,7 @@ module SneakersHandlers
       arguments = { :"x-queue-type" => "quorum", **arguments } if durable
       channel.queue(name, durable: durable, arguments: arguments)
     rescue Bunny::PreconditionFailed
-      channel.queue_delete(name)
+      channel.open.queue_delete(name)
       retry
     end
   end

--- a/lib/sneakers_handlers/exponential_backoff_handler.rb
+++ b/lib/sneakers_handlers/exponential_backoff_handler.rb
@@ -154,18 +154,8 @@ module SneakersHandlers
     end
 
     def create_retry_queue!(delay)
-      queue_name = "#{queue.name}.retry.#{delay}"
-
-      # When we create a new queue, `Bunny` stores its name in an internal cache.
-      # The problem is that as we are creating ephemeral queues that can expire shortly
-      # after they are created, this cached queue may not exist anymore when we try to
-      # publish a second message to it.
-      # Removing queues from the cache guarantees that `Bunny` will always try
-      # to check if they exist, and when they don't, it will create them for us.
-      channel.deregister_queue_named(queue_name)
-
       create_queue!(
-        queue_name,
+        "#{queue.name}.retry.#{delay}",
         :"x-dead-letter-exchange" => options[:exchange],
         :"x-dead-letter-routing-key" => queue.name,
         :"x-message-ttl" => delay * 1_000,

--- a/lib/sneakers_handlers/exponential_backoff_handler.rb
+++ b/lib/sneakers_handlers/exponential_backoff_handler.rb
@@ -169,7 +169,6 @@ module SneakersHandlers
         :"x-dead-letter-exchange" => options[:exchange],
         :"x-dead-letter-routing-key" => queue.name,
         :"x-message-ttl" => delay * 1_000,
-        :"x-expires" => delay * 1_000 * 2
       )
     end
 

--- a/lib/sneakers_handlers/exponential_backoff_handler.rb
+++ b/lib/sneakers_handlers/exponential_backoff_handler.rb
@@ -177,6 +177,9 @@ module SneakersHandlers
       durable = options[:queue_options][:durable]
       arguments = { :"x-queue-type" => "quorum", **arguments } if durable
       channel.queue(name, durable: durable, arguments: arguments)
+    rescue Bunny::PreconditionFailed
+      channel.queue_delete(name)
+      retry
     end
   end
 end


### PR DESCRIPTION
- Создаем очереди с типом quorum.
- При получении ошибки PreconditionFailed (уже есть такая очередь с типом classic), пересоздаем очередь.
- Убираем `x-expires` с retry-очередей, т.к. параметр не работает нормально с кворум очередями.